### PR TITLE
Fix properly return promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,11 +134,12 @@ module.exports = function fluxibleProfilingPlugin(options) {
     }
   };
 
-  function printActionDuration(actionName, startTime) {
+  function printActionDuration(actionName, startTime, promiseResult) {
     if (opts.printActionDuration) {
       console.log('FINISHED executing', actionName + ', duration:', msSince(startTime));
       consoleBlankLine();
     }
+    return promiseResult;
   }
 
   function printReactMeasurements(eventName, startTime) {


### PR DESCRIPTION
Fixes this scenario:

```
function action1() {
   var promise = new Promise(function(resolve) {
       resolve('some data');
   } )

   return promise;   
}

function action2(context) {
   return context.executeAction(action1)
   .then((data) => console.log(data)) // undefined
}
```
